### PR TITLE
Harden MCP request validation and protocol negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ The Worker implementation is usable in production for the main Bark flows.
 
 Current validation coverage:
 
-- `42` automated tests passing with `pnpm test`
+- `92` automated tests passing with `pnpm test`
 - TypeScript checks passing with `pnpm check`
 - Wrangler dry-run build passing with `pnpm build`
 - Live smoke tests confirmed for legacy push, `/push`, `/mcp`, and `/mcp/:device_key`
 
-> **中文说明：** Worker 实现已可用于生产环境，覆盖主要 Bark 推送流程。旧版推送路由、`POST /push`、MCP 端点均已可用，APNs 推送经过真机验证，兼容性行为由自动化合约测试覆盖。当前 42 个自动化测试全部通过。
+> **中文说明：** Worker 实现已可用于生产环境，覆盖主要 Bark 推送流程。旧版推送路由、`POST /push`、MCP 端点均已可用，APNs 推送经过真机验证，兼容性行为由自动化合约测试覆盖。当前 92 个自动化测试全部通过。
 
 ## Migration Approach
 
@@ -214,8 +214,9 @@ Optional hardening variables ｜ 可选安全加固变量:
 - `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` protect all non-compatibility-free routes. `/`, `/ping`, `/healthz`, and `/register` still bypass auth for Bark compatibility.
 - `MAX_BATCH_PUSH_COUNT` limits V2 batch fan-out when `device_keys` is provided.
 - `MAX_REQUEST_BODY_BYTES` limits parsed request bodies for JSON/form/MCP requests. The default is `4194304` bytes.
+- `MCP_SESSION_SECRET` signs optional MCP session IDs. It is not an access-control boundary: requests without `Mcp-Session-Id` are still accepted for compatibility, so use Basic Auth to restrict MCP access.
 
-> **中文说明：** `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` 保护所有非兼容性免费路由（`/`、`/ping`、`/healthz`、`/register` 仍绕过认证以保持 Bark 兼容）。`MAX_BATCH_PUSH_COUNT` 限制 `device_keys` 批量推送数量。`MAX_REQUEST_BODY_BYTES` 限制 JSON/form/MCP 请求体大小，默认 4MB。
+> **中文说明：** `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` 保护所有非兼容性免费路由（`/`、`/ping`、`/healthz`、`/register` 仍绕过认证以保持 Bark 兼容）。`MAX_BATCH_PUSH_COUNT` 限制 `device_keys` 批量推送数量。`MAX_REQUEST_BODY_BYTES` 限制 JSON/form/MCP 请求体大小，默认 4MB。`MCP_SESSION_SECRET` 用于签名可选 MCP session ID，但它不是访问控制边界；为了兼容，未携带 `Mcp-Session-Id` 的请求仍会被接受，限制 MCP 访问请使用 Basic Auth。
 
 If you prefer, `APNS_PRIVATE_KEY` can be stored as a Cloudflare secret instead of plaintext config:
 
@@ -265,11 +266,13 @@ The Worker exposes Bark push as an MCP tool so AI agents can notify you when tas
 
 The transport follows the MCP Streamable HTTP rules for version negotiation and optional sessions, but this deployment model intentionally does not keep a standalone SSE stream open.
 
-If `MCP_SESSION_SECRET` is configured, `initialize` returns `Mcp-Session-Id` and clients may reuse it on later requests. Existing clients may still skip `initialize` and call tools directly for backward compatibility.
+If `MCP_SESSION_SECRET` is configured, `initialize` returns `Mcp-Session-Id` and clients may reuse it on later requests. Existing clients may still skip `initialize` and call tools directly for backward compatibility, so the session secret is not a replacement for Basic Auth.
+
+The MCP endpoint accepts one JSON-RPC message per POST. JSON-RPC batch arrays are rejected with `400`.
 
 This is useful for long-running agents such as Claude Code or Codex that should send a Bark notification at task completion.
 
-> **中文说明：** Worker 将 Bark 推送暴露为 MCP 工具，供 AI 代理在任务完成或需要关注时通知你。`POST /mcp` 需要 `device_key`，`POST /mcp/:device_key` 则不需要；MCP 端点的 `GET` / `DELETE` 会返回 `405 Method Not Allowed`。传输层遵循现代 Streamable HTTP 的版本协商和可选 session 语义，但当前部署不会保持独立 SSE 流。若配置 `MCP_SESSION_SECRET`，`initialize` 会返回 `Mcp-Session-Id` 供后续请求复用；为了兼容现有客户端，仍允许跳过 `initialize` 直接调用工具。
+> **中文说明：** Worker 将 Bark 推送暴露为 MCP 工具，供 AI 代理在任务完成或需要关注时通知你。`POST /mcp` 需要 `device_key`，`POST /mcp/:device_key` 则不需要；MCP 端点的 `GET` / `DELETE` 会返回 `405 Method Not Allowed`。传输层遵循现代 Streamable HTTP 的版本协商和可选 session 语义，但当前部署不会保持独立 SSE 流。若配置 `MCP_SESSION_SECRET`，`initialize` 会返回 `Mcp-Session-Id` 供后续请求复用；为了兼容现有客户端，仍允许跳过 `initialize` 直接调用工具，因此 session secret 不能替代 Basic Auth。MCP 端点每个 POST 接受一条 JSON-RPC 消息，JSON-RPC 批量数组会返回 `400`。
 
 ## Development ｜ 开发
 

--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ Update the `[vars]` section in `wrangler.toml`:
 Optional hardening variables ｜ 可选安全加固变量:
 
 - `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` protect all non-compatibility-free routes. `/`, `/ping`, `/healthz`, and `/register` still bypass auth for Bark compatibility.
-- `MAX_BATCH_PUSH_COUNT` limits V2 batch fan-out when `device_keys` is provided.
+- `MAX_BATCH_PUSH_COUNT` limits V2 batch fan-out when `device_keys` is provided. The default is `1000`; set `-1` only if you intentionally want no application-level cap.
 - `MAX_REQUEST_BODY_BYTES` limits parsed request bodies for JSON/form/MCP requests. The default is `4194304` bytes.
 - `MCP_SESSION_SECRET` signs optional MCP session IDs. It is not an access-control boundary: requests without `Mcp-Session-Id` are still accepted for compatibility, so use Basic Auth to restrict MCP access.
 
-> **中文说明：** `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` 保护所有非兼容性免费路由（`/`、`/ping`、`/healthz`、`/register` 仍绕过认证以保持 Bark 兼容）。`MAX_BATCH_PUSH_COUNT` 限制 `device_keys` 批量推送数量。`MAX_REQUEST_BODY_BYTES` 限制 JSON/form/MCP 请求体大小，默认 4MB。`MCP_SESSION_SECRET` 用于签名可选 MCP session ID，但它不是访问控制边界；为了兼容，未携带 `Mcp-Session-Id` 的请求仍会被接受，限制 MCP 访问请使用 Basic Auth。
+> **中文说明：** `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` 保护所有非兼容性免费路由（`/`、`/ping`、`/healthz`、`/register` 仍绕过认证以保持 Bark 兼容）。`MAX_BATCH_PUSH_COUNT` 限制 `device_keys` 批量推送数量，默认 `1000`；只有在你明确接受无应用层上限时才应设为 `-1`。`MAX_REQUEST_BODY_BYTES` 限制 JSON/form/MCP 请求体大小，默认 4MB。`MCP_SESSION_SECRET` 用于签名可选 MCP session ID，但它不是访问控制边界；为了兼容，未携带 `Mcp-Session-Id` 的请求仍会被接受，限制 MCP 访问请使用 Basic Auth。
 
 If you prefer, `APNS_PRIVATE_KEY` can be stored as a Cloudflare secret instead of plaintext config:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -11,7 +11,9 @@ Bark supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io
 
 `GET` and `DELETE` on these endpoints return `405 Method Not Allowed`.
 
-If `MCP_SESSION_SECRET` is configured, `initialize` returns `Mcp-Session-Id`, which clients may reuse on later requests. Existing clients may still skip `initialize` and call tools directly for backward compatibility.
+If `MCP_SESSION_SECRET` is configured, `initialize` returns `Mcp-Session-Id`, which clients may reuse on later requests. Existing clients may still skip `initialize` and call tools directly for backward compatibility, so the session secret is not an access-control boundary. Use Basic Auth to restrict MCP access.
+
+The endpoint accepts one JSON-RPC message per POST. JSON-RPC batch arrays are rejected with `400`.
 
 ### Examples
 

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -5,7 +5,7 @@ import { createBasicAuthMiddleware } from "@/auth";
 import { normalizeUrlPrefix } from "@/config";
 import { registerMcpRoutes } from "@/mcp";
 import { registerPushRoutes } from "@/push";
-import { getErrorMessage, failed } from "@/responses";
+import { getErrorMessage, failed, INTERNAL_ERROR_MESSAGE } from "@/responses";
 import { registerRegisterRoutes } from "@/register";
 import type { AppConfig, RuntimeDeps } from "@/types";
 
@@ -80,7 +80,12 @@ export function createApp(options: CreateAppOptions): Hono {
   app.notFound((c) => c.text("404 Not Found", 404));
   app.onError((error, c) => {
     const status = error instanceof HTTPException ? error.status : 500;
-    return c.json(failed(options.deps.now(), status, getErrorMessage(error)), status);
+    if (status >= 500) {
+      console.error("Unhandled request error", error);
+    }
+
+    const message = status >= 500 ? INTERNAL_ERROR_MESSAGE : getErrorMessage(error);
+    return c.json(failed(options.deps.now(), status, message), status);
   });
 
   return app;

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -4,7 +4,18 @@ import { normalizeUrlPrefix } from "@/config";
 import { timingSafeStringEqual } from "@/timing-safe";
 import type { AppConfig } from "@/types";
 
-const AUTH_FREE_ROUTES = ["/ping", "/register", "/healthz"];
+interface AuthFreeRoute {
+  method: string;
+  path: string;
+}
+
+const AUTH_FREE_ROUTES: AuthFreeRoute[] = [
+  { method: "GET", path: "/" },
+  { method: "GET", path: "/ping" },
+  { method: "GET", path: "/healthz" },
+  { method: "GET", path: "/register" },
+  { method: "POST", path: "/register" },
+];
 
 function decodeBasicAuth(header: string | undefined): string | null {
   if (!header || !header.startsWith("Basic ")) {
@@ -32,14 +43,25 @@ function stripPrefix(pathname: string, prefix: string): string {
   return relative.length === 0 ? "/" : relative;
 }
 
-function isAuthFreePath(relativePath: string): boolean {
-  if (relativePath === "/") {
+function isRegisterCheckPath(method: string, relativePath: string): boolean {
+  if (method !== "GET") {
+    return false;
+  }
+
+  const prefix = "/register/";
+  if (!relativePath.startsWith(prefix)) {
+    return false;
+  }
+
+  return relativePath.slice(prefix.length).length > 0;
+}
+
+function isAuthFreeRoute(method: string, relativePath: string): boolean {
+  if (AUTH_FREE_ROUTES.some((route) => route.method === method && route.path === relativePath)) {
     return true;
   }
 
-  return AUTH_FREE_ROUTES.some((item) => {
-    return relativePath === item || relativePath.startsWith(`${item}/`);
-  });
+  return isRegisterCheckPath(method, relativePath);
 }
 
 export function createBasicAuthMiddleware(config: AppConfig): MiddlewareHandler {
@@ -54,7 +76,7 @@ export function createBasicAuthMiddleware(config: AppConfig): MiddlewareHandler 
     const pathname = new URL(c.req.url).pathname;
     const relativePath = stripPrefix(pathname, config.urlPrefix);
 
-    if (isAuthFreePath(relativePath)) {
+    if (isAuthFreeRoute(c.req.method, relativePath)) {
       await next();
       return;
     }

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -53,7 +53,8 @@ function isRegisterCheckPath(method: string, relativePath: string): boolean {
     return false;
   }
 
-  return relativePath.slice(prefix.length).length > 0;
+  const rest = relativePath.slice(prefix.length);
+  return rest.length > 0 && !rest.includes("/");
 }
 
 function isAuthFreeRoute(method: string, relativePath: string): boolean {

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareHandler } from "hono";
 
 import { normalizeUrlPrefix } from "@/config";
+import { timingSafeStringEqual } from "@/timing-safe";
 import type { AppConfig } from "@/types";
 
 const AUTH_FREE_ROUTES = ["/ping", "/register", "/healthz"];
@@ -15,19 +16,6 @@ function decodeBasicAuth(header: string | undefined): string | null {
   } catch {
     return null;
   }
-}
-
-function timingSafeStringEqual(actual: string | null, expected: string): boolean {
-  if (actual === null) {
-    return false;
-  }
-
-  let diff = actual.length ^ expected.length;
-  for (let i = 0; i < expected.length; i++) {
-    diff |= actual.charCodeAt(i) ^ expected.charCodeAt(i);
-  }
-
-  return diff === 0;
 }
 
 function stripPrefix(pathname: string, prefix: string): string {

--- a/worker/src/cloudflare-apns-client.ts
+++ b/worker/src/cloudflare-apns-client.ts
@@ -266,7 +266,7 @@ export class CloudflareApnsClient implements PushSender {
       headers["apns-collapse-id"] = message.id;
     }
 
-    const url = `https://api.push.apple.com/3/device/${message.deviceToken}`;
+    const url = `https://api.push.apple.com/3/device/${encodeURIComponent(message.deviceToken)}`;
 
     let response: Response;
     try {

--- a/worker/src/cloudflare-apns-client.ts
+++ b/worker/src/cloudflare-apns-client.ts
@@ -134,7 +134,8 @@ function stringifyCustomField(value: unknown): string {
   }
 
   try {
-    return JSON.stringify(value);
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
   } catch {
     return String(value);
   }

--- a/worker/src/cloudflare-apns-client.ts
+++ b/worker/src/cloudflare-apns-client.ts
@@ -8,6 +8,7 @@ export interface CloudflareApnsConfig {
 }
 
 const JWT_REUSE_SECONDS = 30 * 60;
+const RESERVED_PAYLOAD_KEYS = new Set(["aps"]);
 
 function trimLeadingZeroes(bytes: Uint8Array): Uint8Array {
   let start = 0;
@@ -117,6 +118,28 @@ function normalizePemText(pem: string): string {
   return pem.replace(/\\r/g, "\r").replace(/\\n/g, "\n").trim();
 }
 
+function stringifyCustomField(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    value === null ||
+    value === undefined
+  ) {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 function parsePemPrivateKey(pem: string): ArrayBuffer {
   const normalizedPem = normalizePemText(pem);
   const match = normalizedPem.match(
@@ -223,7 +246,12 @@ export class CloudflareApnsClient implements PushSender {
     }
 
     for (const [key, value] of Object.entries(message.extParams)) {
-      payload[key.toLowerCase()] = String(value);
+      const normalizedKey = key.toLowerCase();
+      if (RESERVED_PAYLOAD_KEYS.has(normalizedKey)) {
+        continue;
+      }
+
+      payload[normalizedKey] = stringifyCustomField(value);
     }
 
     const headers: Record<string, string> = {

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -1,6 +1,8 @@
 import type { AppConfig, BarkBindings, BuildInfo } from "@/types";
 import { DEFAULT_MAX_REQUEST_BODY_BYTES } from "@/validation";
 
+export const DEFAULT_MAX_BATCH_PUSH_COUNT = 1000;
+
 export function normalizeUrlPrefix(prefix?: string): string {
   if (!prefix || prefix === "/") {
     return "/";
@@ -12,11 +14,15 @@ export function normalizeUrlPrefix(prefix?: string): string {
 
 export function parseMaxBatchPushCount(raw?: string): number {
   if (!raw) {
-    return -1;
+    return DEFAULT_MAX_BATCH_PUSH_COUNT;
   }
 
   const parsed = Number.parseInt(raw, 10);
-  return Number.isNaN(parsed) ? -1 : parsed;
+  if (parsed === -1) {
+    return -1;
+  }
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_BATCH_PUSH_COUNT;
 }
 
 export function parseMaxRequestBodyBytes(raw?: string): number {

--- a/worker/src/device-key.ts
+++ b/worker/src/device-key.ts
@@ -1,13 +1,26 @@
 const ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const DEFAULT_LENGTH = 22;
+const ALPHABET_LENGTH = ALPHABET.length;
+const ACCEPTANCE_LIMIT = Math.floor(256 / ALPHABET_LENGTH) * ALPHABET_LENGTH;
 
 export function generateDeviceKey(length = DEFAULT_LENGTH): string {
-  const buffer = new Uint8Array(length);
-  crypto.getRandomValues(buffer);
-
   let output = "";
-  for (const value of buffer) {
-    output += ALPHABET[value % ALPHABET.length];
+
+  while (output.length < length) {
+    const buffer = new Uint8Array(length - output.length);
+    crypto.getRandomValues(buffer);
+
+    for (const value of buffer) {
+      if (value >= ACCEPTANCE_LIMIT) {
+        continue;
+      }
+
+      output += ALPHABET[value % ALPHABET_LENGTH];
+      if (output.length === length) {
+        break;
+      }
+    }
   }
+
   return output;
 }

--- a/worker/src/kv-device-registry.ts
+++ b/worker/src/kv-device-registry.ts
@@ -2,15 +2,29 @@ import { generateDeviceKey } from "@/device-key";
 import type { DeviceRegistry } from "@/types";
 
 const DEVICE_KEY_PREFIX = "device:";
+const DEVICE_COUNT_CACHE_TTL_MS = 60 * 1000;
 
 function storageKey(key: string): string {
   return `${DEVICE_KEY_PREFIX}${key}`;
 }
 
 export class KVDeviceRegistry implements DeviceRegistry {
-  constructor(private readonly namespace: KVNamespace) {}
+  private cachedCount: { value: number; expiresAt: number } | null = null;
+
+  constructor(
+    private readonly namespace: KVNamespace,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  private invalidateCountCache(): void {
+    this.cachedCount = null;
+  }
 
   async countAll(): Promise<number> {
+    if (this.cachedCount && this.cachedCount.expiresAt > this.now()) {
+      return this.cachedCount.value;
+    }
+
     let cursor: string | undefined;
     let total = 0;
 
@@ -19,6 +33,11 @@ export class KVDeviceRegistry implements DeviceRegistry {
       total += page.keys.length;
       cursor = page.list_complete ? undefined : page.cursor;
     } while (cursor);
+
+    this.cachedCount = {
+      value: total,
+      expiresAt: this.now() + DEVICE_COUNT_CACHE_TTL_MS,
+    };
 
     return total;
   }
@@ -39,14 +58,17 @@ export class KVDeviceRegistry implements DeviceRegistry {
 
     if (token.length === 0) {
       await this.namespace.delete(storageKey(nextKey));
+      this.invalidateCountCache();
       return nextKey;
     }
 
     await this.namespace.put(storageKey(nextKey), token);
+    this.invalidateCountCache();
     return nextKey;
   }
 
   async deleteDeviceByKey(key: string): Promise<void> {
     await this.namespace.delete(storageKey(key));
+    this.invalidateCountCache();
   }
 }

--- a/worker/src/mcp.ts
+++ b/worker/src/mcp.ts
@@ -2,6 +2,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Context, Hono } from "hono";
 
 import { pushOne } from "@/push";
+import { timingSafeStringEqual } from "@/timing-safe";
 import type { AppConfig, RuntimeDeps } from "@/types";
 import { readLimitedText } from "@/validation";
 
@@ -10,7 +11,12 @@ export interface McpRouteOptions {
   deps: RuntimeDeps;
 }
 
-const SUPPORTED_PROTOCOL_VERSIONS = new Set(["2025-03-26", "2025-06-18"]);
+const ACCEPTED_PROTOCOL_VERSIONS = ["2025-03-26", "2025-06-18"] as const;
+const LEGACY_INITIALIZE_PROTOCOL_VERSIONS = ["2024-11-05"] as const;
+const SUPPORTED_PROTOCOL_VERSIONS = new Set<string>(ACCEPTED_PROTOCOL_VERSIONS);
+const LEGACY_INITIALIZE_PROTOCOL_VERSION_SET = new Set<string>(
+  LEGACY_INITIALIZE_PROTOCOL_VERSIONS,
+);
 const SERVER_PROTOCOL_VERSION = "2025-06-18";
 const SESSION_TTL_SECONDS = 24 * 60 * 60;
 const PROTOCOL_HEADER = "MCP-Protocol-Version";
@@ -61,12 +67,24 @@ type ProtocolValidationResult =
   | { valid: true; version: string | null }
   | { valid: false; version: string };
 
+type InitializeNegotiationResult =
+  | { valid: true; version: string }
+  | { valid: false; version: string };
+
 function normalizeJsonRpcId(id: unknown): JsonRpcId {
   if (typeof id === "number" || typeof id === "string" || id === null) {
     return id;
   }
 
   return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonRpcObject(value: unknown): value is JsonRpcRequest {
+  return isRecord(value) && value.jsonrpc === "2.0";
 }
 
 function isJsonRpcNotification(body: JsonRpcRequest): boolean {
@@ -149,7 +167,7 @@ async function validateSessionToken(
   const signatureB64 = token.slice(dotIndex + 1);
 
   const expectedSig = await hmacSign(secret, payloadB64);
-  if (signatureB64 !== expectedSig) {
+  if (!timingSafeStringEqual(signatureB64, expectedSig)) {
     return { valid: false, status: 400, message: "Invalid session signature" };
   }
 
@@ -180,8 +198,13 @@ function setProtocolHeader(c: Context, version = SERVER_PROTOCOL_VERSION): void 
   c.header(PROTOCOL_HEADER, version);
 }
 
-function protocolError(c: Context, message: string, status: 400): Response {
-  setProtocolHeader(c);
+function protocolError(
+  c: Context,
+  message: string,
+  status: 400,
+  version = SERVER_PROTOCOL_VERSION,
+): Response {
+  setProtocolHeader(c, version);
   return c.json(
     {
       jsonrpc: "2.0",
@@ -190,6 +213,13 @@ function protocolError(c: Context, message: string, status: 400): Response {
     } satisfies JsonRpcErrorResponse,
     status,
   );
+}
+
+function responseProtocolVersionForHeader(headerValue: string | undefined): string {
+  const validation = validateProtocolHeader(headerValue);
+  return validation.valid && validation.version !== null
+    ? validation.version
+    : SERVER_PROTOCOL_VERSION;
 }
 
 function validateProtocolHeader(headerValue: string | undefined): ProtocolValidationResult {
@@ -202,6 +232,24 @@ function validateProtocolHeader(headerValue: string | undefined): ProtocolValida
   }
 
   return { valid: false, version: headerValue };
+}
+
+function negotiateInitializeProtocolVersion(
+  clientVersion: string | undefined,
+): InitializeNegotiationResult {
+  if (clientVersion === undefined) {
+    return { valid: true, version: SERVER_PROTOCOL_VERSION };
+  }
+
+  if (SUPPORTED_PROTOCOL_VERSIONS.has(clientVersion)) {
+    return { valid: true, version: clientVersion };
+  }
+
+  if (LEGACY_INITIALIZE_PROTOCOL_VERSION_SET.has(clientVersion)) {
+    return { valid: true, version: SERVER_PROTOCOL_VERSION };
+  }
+
+  return { valid: false, version: clientVersion };
 }
 
 function buildNotifyTool(deviceKeyRequired: boolean) {
@@ -265,6 +313,7 @@ async function handleMcpRequest(
   body: JsonRpcRequest,
   pathDeviceKey: string | null,
   options: McpRouteOptions,
+  negotiatedInitializeProtocolVersion?: string,
 ): Promise<McpHandlerResult> {
   const id = normalizeJsonRpcId(body.id);
 
@@ -280,11 +329,12 @@ async function handleMcpRequest(
     case "initialize": {
       const clientVersion = (body.params as Record<string, unknown> | undefined)
         ?.protocolVersion as string | undefined;
+      const negotiation =
+        negotiatedInitializeProtocolVersion !== undefined
+          ? { valid: true as const, version: negotiatedInitializeProtocolVersion }
+          : negotiateInitializeProtocolVersion(clientVersion);
 
-      if (
-        clientVersion !== undefined &&
-        !SUPPORTED_PROTOCOL_VERSIONS.has(clientVersion)
-      ) {
+      if (!negotiation.valid) {
         return {
           kind: "response",
           status: 400,
@@ -293,7 +343,7 @@ async function handleMcpRequest(
             id,
             error: {
               code: -32602,
-              message: `Unsupported protocol version: ${clientVersion}. Supported: ${[...SUPPORTED_PROTOCOL_VERSIONS].join(", ")}`,
+              message: `Unsupported protocol version: ${negotiation.version}. Supported: ${[...SUPPORTED_PROTOCOL_VERSIONS].join(", ")}`,
             },
           },
         };
@@ -305,7 +355,7 @@ async function handleMcpRequest(
           jsonrpc: "2.0",
           id,
           result: {
-            protocolVersion: SERVER_PROTOCOL_VERSION,
+            protocolVersion: negotiation.version,
             capabilities: { tools: { listChanged: false } },
             serverInfo: {
               name: "Bark MCP Server",
@@ -427,11 +477,16 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
   async function handlePost(c: Context, pathDeviceKey: string | null) {
     const protocolHeader = c.req.header("mcp-protocol-version");
     const protocolValidation = validateProtocolHeader(protocolHeader);
+    let responseProtocolVersion =
+      protocolValidation.valid && protocolValidation.version !== null
+        ? protocolValidation.version
+        : SERVER_PROTOCOL_VERSION;
     if (!protocolValidation.valid) {
       return protocolError(
         c,
         `Unsupported protocol version: ${protocolValidation.version}. Supported: ${[...SUPPORTED_PROTOCOL_VERSIONS].join(", ")}`,
         400,
+        responseProtocolVersion,
       );
     }
 
@@ -441,7 +496,7 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
       const requestUrl = new URL(c.req.url);
       const requestOrigin = `${requestUrl.protocol}//${requestUrl.host}`;
       if (origin !== requestOrigin) {
-        setProtocolHeader(c);
+        setProtocolHeader(c, responseProtocolVersion);
         return c.text("Forbidden: Origin mismatch", 403);
       }
     }
@@ -449,7 +504,7 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
     // Accept header validation
     const accept = c.req.header("accept");
     if (accept !== undefined && !accept.includes("application/json")) {
-      setProtocolHeader(c);
+      setProtocolHeader(c, responseProtocolVersion);
       return c.text("Not Acceptable", 406);
     }
 
@@ -462,19 +517,21 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
         c,
         "Session management is not enabled on this server",
         400,
+        responseProtocolVersion,
       );
     }
 
     // Parse body
+    let parsed: unknown;
     let body: JsonRpcRequest;
     try {
       const raw = await readLimitedText(
         c.req.raw,
         options.config.maxRequestBodyBytes,
       );
-      body = JSON.parse(raw) as JsonRpcRequest;
+      parsed = JSON.parse(raw);
     } catch {
-      setProtocolHeader(c);
+      setProtocolHeader(c, responseProtocolVersion);
       return c.json(
         {
           jsonrpc: "2.0",
@@ -485,11 +542,41 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
       );
     }
 
+    if (Array.isArray(parsed)) {
+      setProtocolHeader(c, responseProtocolVersion);
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          id: null,
+          error: {
+            code: -32600,
+            message: "JSON-RPC batch requests are not supported",
+          },
+        } satisfies JsonRpcErrorResponse,
+        400,
+      );
+    }
+
+    if (!isJsonRpcObject(parsed)) {
+      setProtocolHeader(c, responseProtocolVersion);
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32600, message: "Invalid Request" },
+        } satisfies JsonRpcErrorResponse,
+        400,
+      );
+    }
+
+    body = parsed;
+
+    let negotiatedInitializeProtocolVersion: string | undefined;
     if (body.method === "initialize") {
       const clientVersion = (body.params as Record<string, unknown> | undefined)
         ?.protocolVersion as string | undefined;
       if (clientVersion !== undefined && protocolHeader !== undefined && clientVersion !== protocolHeader) {
-        setProtocolHeader(c);
+        setProtocolHeader(c, responseProtocolVersion);
         return c.json(
           {
             jsonrpc: "2.0",
@@ -501,6 +588,14 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
           } satisfies JsonRpcErrorResponse,
           400,
         );
+      }
+
+      const negotiation = negotiateInitializeProtocolVersion(
+        clientVersion ?? protocolHeader,
+      );
+      if (negotiation.valid) {
+        responseProtocolVersion = negotiation.version;
+        negotiatedInitializeProtocolVersion = negotiation.version;
       }
     }
 
@@ -517,7 +612,7 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
       );
 
       if (!validation.valid) {
-        setProtocolHeader(c);
+        setProtocolHeader(c, responseProtocolVersion);
         return c.json(
           {
             jsonrpc: "2.0",
@@ -530,10 +625,15 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
     }
 
     // Dispatch
-    const result = await handleMcpRequest(body, pathDeviceKey, options);
+    const result = await handleMcpRequest(
+      body,
+      pathDeviceKey,
+      options,
+      negotiatedInitializeProtocolVersion,
+    );
 
     if (result.kind === "notification" || result.kind === "client-response") {
-      c.header("MCP-Protocol-Version", SERVER_PROTOCOL_VERSION);
+      setProtocolHeader(c, responseProtocolVersion);
       return c.body(null, 202);
     }
 
@@ -547,10 +647,12 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
       const clientVersion = (
         body.params as Record<string, unknown> | undefined
       )?.protocolVersion as string | undefined;
+      const fallbackNegotiation = negotiateInitializeProtocolVersion(clientVersion);
       const negotiatedVersion =
         protocolHeader ??
-        (clientVersion && SUPPORTED_PROTOCOL_VERSIONS.has(clientVersion)
-          ? clientVersion
+        negotiatedInitializeProtocolVersion ??
+        (fallbackNegotiation.valid
+          ? fallbackNegotiation.version
           : SERVER_PROTOCOL_VERSION);
       const scope = pathDeviceKey !== null ? "device" : "global";
 
@@ -564,7 +666,7 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
       c.header("Mcp-Session-Id", token);
     }
 
-    setProtocolHeader(c);
+    setProtocolHeader(c, responseProtocolVersion);
     return c.json(result.body, (result.status ?? 200) as ContentfulStatusCode);
   }
 
@@ -574,7 +676,10 @@ export function registerMcpRoutes(app: Hono, options: McpRouteOptions): void {
   );
 
   const methodNotAllowed = (c: Context) => {
-    setProtocolHeader(c);
+    setProtocolHeader(
+      c,
+      responseProtocolVersionForHeader(c.req.header("mcp-protocol-version")),
+    );
     return c.text("Method Not Allowed", 405);
   };
   app.get("/mcp", methodNotAllowed);

--- a/worker/src/register.ts
+++ b/worker/src/register.ts
@@ -1,6 +1,6 @@
 import type { Context, Hono } from "hono";
 
-import { getErrorMessage, failed, success, withData } from "@/responses";
+import { getErrorMessage, failed, INTERNAL_ERROR_MESSAGE, success, withData } from "@/responses";
 import type { AppConfig, RuntimeDeps } from "@/types";
 import { assertBodyWithinLimit, readLimitedText } from "@/validation";
 
@@ -89,14 +89,8 @@ async function doRegister(c: Context, options: RegisterRouteOptions, compat: boo
       200,
     );
   } catch (error) {
-    return c.json(
-      failed(
-        options.deps.now(),
-        500,
-        `device registration failed: ${getErrorMessage(error)}`,
-      ),
-      500,
-    );
+    console.error("Device registration failed", error);
+    return c.json(failed(options.deps.now(), 500, INTERNAL_ERROR_MESSAGE), 500);
   }
 }
 

--- a/worker/src/responses.ts
+++ b/worker/src/responses.ts
@@ -1,5 +1,7 @@
 import type { CommonResp } from "@/types";
 
+export const INTERNAL_ERROR_MESSAGE = "internal server error";
+
 export function success(now: number): CommonResp {
   return {
     code: 200,

--- a/worker/src/timing-safe.ts
+++ b/worker/src/timing-safe.ts
@@ -1,0 +1,15 @@
+export function timingSafeStringEqual(
+  actual: string | null | undefined,
+  expected: string,
+): boolean {
+  if (actual === null || actual === undefined) {
+    return false;
+  }
+
+  let diff = actual.length ^ expected.length;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= actual.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+
+  return diff === 0;
+}

--- a/worker/test/apns.test.ts
+++ b/worker/test/apns.test.ts
@@ -160,6 +160,33 @@ describe("CloudflareApnsClient", () => {
     expect(payload.metadata).toBe('{"nested":true}');
   });
 
+  it("encodes device tokens before appending them to the APNs path", async () => {
+    installCryptoStub();
+
+    const client = new CloudflareApnsClient({
+      privateKey: TEST_PKCS8_PRIVATE_KEY,
+      keyId: "KEYID123",
+      teamId: "TEAMID123",
+      topic: "me.fin.bark",
+    });
+
+    const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await client.send(
+      createMessage({
+        deviceToken: "abc/../../../../foo?x=y#z",
+      }),
+    );
+
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const url = String(calls[0]![0]);
+
+    expect(url).toBe(
+      "https://api.push.apple.com/3/device/abc%2F..%2F..%2F..%2F..%2Ffoo%3Fx%3Dy%23z",
+    );
+  });
+
   it("emits a JOSE raw ECDSA signature in the JWT", async () => {
     const { sign } = installCryptoStub(makeRawSignature());
 

--- a/worker/test/apns.test.ts
+++ b/worker/test/apns.test.ts
@@ -160,6 +160,34 @@ describe("CloudflareApnsClient", () => {
     expect(payload.metadata).toBe('{"nested":true}');
   });
 
+  it("falls back to String(value) when JSON.stringify returns undefined", async () => {
+    installCryptoStub();
+
+    const client = new CloudflareApnsClient({
+      privateKey: TEST_PKCS8_PRIVATE_KEY,
+      keyId: "KEYID123",
+      teamId: "TEAMID123",
+      topic: "me.fin.bark",
+    });
+
+    const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await client.send(
+      createMessage({
+        extParams: {
+          customSymbol: Symbol("custom"),
+        },
+      }),
+    );
+
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const init = calls[0]![1];
+    const payload = JSON.parse(String(init.body)) as Record<string, unknown>;
+
+    expect(payload.customsymbol).toBe("Symbol(custom)");
+  });
+
   it("encodes device tokens before appending them to the APNs path", async () => {
     installCryptoStub();
 

--- a/worker/test/apns.test.ts
+++ b/worker/test/apns.test.ts
@@ -92,6 +92,74 @@ describe("CloudflareApnsClient", () => {
     expect((payload.aps as Record<string, unknown>).badge).toBeUndefined();
   });
 
+  it("keeps the generated aps dictionary when custom fields include aps", async () => {
+    installCryptoStub();
+
+    const client = new CloudflareApnsClient({
+      privateKey: TEST_PKCS8_PRIVATE_KEY,
+      keyId: "KEYID123",
+      teamId: "TEAMID123",
+      topic: "me.fin.bark",
+    });
+
+    const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await client.send(
+      createMessage({
+        extParams: {
+          aps: "CLOBBERED",
+          customField: "x",
+        },
+      }),
+    );
+
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const init = calls[0]![1];
+    const payload = JSON.parse(String(init.body)) as {
+      aps: Record<string, unknown>;
+      customfield: string;
+    };
+
+    expect(payload.aps).toMatchObject({
+      alert: {
+        title: "Title",
+        subtitle: "Subtitle",
+        body: "Body",
+      },
+      sound: "minuet.caf",
+    });
+    expect(payload.customfield).toBe("x");
+  });
+
+  it("serializes object custom fields as JSON strings", async () => {
+    installCryptoStub();
+
+    const client = new CloudflareApnsClient({
+      privateKey: TEST_PKCS8_PRIVATE_KEY,
+      keyId: "KEYID123",
+      teamId: "TEAMID123",
+      topic: "me.fin.bark",
+    });
+
+    const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await client.send(
+      createMessage({
+        extParams: {
+          metadata: { nested: true },
+        },
+      }),
+    );
+
+    const calls = fetchMock.mock.calls as unknown as Array<[unknown, RequestInit]>;
+    const init = calls[0]![1];
+    const payload = JSON.parse(String(init.body)) as Record<string, unknown>;
+
+    expect(payload.metadata).toBe('{"nested":true}');
+  });
+
   it("emits a JOSE raw ECDSA signature in the JWT", async () => {
     const { sign } = installCryptoStub(makeRawSignature());
 

--- a/worker/test/auth.test.ts
+++ b/worker/test/auth.test.ts
@@ -32,6 +32,33 @@ describe("basic auth compatibility", () => {
     await expect(
       app.request("http://example.com/register?devicetoken=abc"),
     ).resolves.toMatchObject({ status: 200 });
+    await expect(app.request("http://example.com/register/demo-key")).resolves.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("blocks auth-free path prefixes that fall through to push routes", async () => {
+    const { app } = createHarness({
+      config: {
+        basicAuthUser: "demo",
+        basicAuthPassword: "secret",
+      },
+      registrySeed: {
+        ping: "token-ping",
+        healthz: "token-healthz",
+        register: "token-register",
+      },
+    });
+
+    await expect(app.request("http://example.com/ping", { method: "POST" })).resolves.toMatchObject({
+      status: 418,
+    });
+    await expect(
+      app.request("http://example.com/healthz", { method: "POST" }),
+    ).resolves.toMatchObject({ status: 418 });
+    await expect(
+      app.request("http://example.com/register/demo-key", { method: "POST" }),
+    ).resolves.toMatchObject({ status: 418 });
   });
 
   it("returns teapot for protected routes without credentials", async () => {

--- a/worker/test/auth.test.ts
+++ b/worker/test/auth.test.ts
@@ -38,7 +38,7 @@ describe("basic auth compatibility", () => {
   });
 
   it("blocks auth-free path prefixes that fall through to push routes", async () => {
-    const { app } = createHarness({
+    const { app, sender } = createHarness({
       config: {
         basicAuthUser: "demo",
         basicAuthPassword: "secret",
@@ -59,6 +59,13 @@ describe("basic auth compatibility", () => {
     await expect(
       app.request("http://example.com/register/demo-key", { method: "POST" }),
     ).resolves.toMatchObject({ status: 418 });
+    await expect(app.request("http://example.com/register/a/b")).resolves.toMatchObject({
+      status: 418,
+    });
+    await expect(app.request("http://example.com/register/a/b/c")).resolves.toMatchObject({
+      status: 418,
+    });
+    expect(sender.messages).toHaveLength(0);
   });
 
   it("returns teapot for protected routes without credentials", async () => {

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_MAX_BATCH_PUSH_COUNT, parseMaxBatchPushCount } from "@/config";
+
+describe("parseMaxBatchPushCount", () => {
+  it("uses a finite default when the env var is absent", () => {
+    expect(parseMaxBatchPushCount()).toBe(DEFAULT_MAX_BATCH_PUSH_COUNT);
+  });
+
+  it("keeps explicit unlimited mode for -1", () => {
+    expect(parseMaxBatchPushCount("-1")).toBe(-1);
+  });
+
+  it("falls back to the finite default for invalid values", () => {
+    expect(parseMaxBatchPushCount("0")).toBe(DEFAULT_MAX_BATCH_PUSH_COUNT);
+    expect(parseMaxBatchPushCount("abc")).toBe(DEFAULT_MAX_BATCH_PUSH_COUNT);
+  });
+});

--- a/worker/test/device-key.test.ts
+++ b/worker/test/device-key.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { generateDeviceKey } from "@/device-key";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("generateDeviceKey", () => {
+  it("returns keys with the expected length and alphabet", () => {
+    const key = generateDeviceKey();
+
+    expect(key).toHaveLength(22);
+    expect(key).toMatch(/^[23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$/);
+  });
+
+  it("rejects out-of-range bytes instead of using modulo bias", () => {
+    const getRandomValues = vi
+      .fn<(buffer: Uint8Array) => Uint8Array>()
+      .mockImplementationOnce((buffer) => {
+        buffer[0] = 255;
+        return buffer;
+      })
+      .mockImplementationOnce((buffer) => {
+        buffer[0] = 0;
+        return buffer;
+      });
+
+    vi.stubGlobal("crypto", {
+      ...globalThis.crypto,
+      getRandomValues,
+    });
+
+    expect(generateDeviceKey(1)).toBe("2");
+    expect(getRandomValues).toHaveBeenCalledTimes(2);
+  });
+});

--- a/worker/test/helpers/fakes.ts
+++ b/worker/test/helpers/fakes.ts
@@ -1,4 +1,5 @@
 import { createApp } from "@/app";
+import { DEFAULT_MAX_BATCH_PUSH_COUNT } from "@/config";
 import type {
   ApnsSendError,
   AppConfig,
@@ -105,7 +106,7 @@ export function createHarness(options: TestHarnessOptions = {}): TestHarness {
     urlPrefix: "/",
     basicAuthUser: undefined,
     basicAuthPassword: undefined,
-    maxBatchPushCount: -1,
+    maxBatchPushCount: DEFAULT_MAX_BATCH_PUSH_COUNT,
     maxRequestBodyBytes: 4 * 1024 * 1024,
     mcpSessionSecret: undefined,
     ...options.config,

--- a/worker/test/kv-device-registry.test.ts
+++ b/worker/test/kv-device-registry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { KVDeviceRegistry } from "@/kv-device-registry";
+
+function createNamespace() {
+  return {
+    list: vi.fn(async () => ({
+      keys: [{ name: "device:alpha" }, { name: "device:beta" }],
+      list_complete: true,
+      cursor: "",
+    })),
+    get: vi.fn(),
+    put: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+  } as unknown as KVNamespace;
+}
+
+describe("KVDeviceRegistry count caching", () => {
+  it("reuses a recent cached device count", async () => {
+    const namespace = createNamespace();
+    let now = 1_000;
+    const registry = new KVDeviceRegistry(namespace, () => now);
+
+    await expect(registry.countAll()).resolves.toBe(2);
+    await expect(registry.countAll()).resolves.toBe(2);
+
+    expect(namespace.list).toHaveBeenCalledTimes(1);
+
+    now += 60_001;
+    await expect(registry.countAll()).resolves.toBe(2);
+
+    expect(namespace.list).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates the cached count after writes", async () => {
+    const namespace = createNamespace();
+    const registry = new KVDeviceRegistry(namespace, () => 1_000);
+
+    await registry.countAll();
+    await registry.saveDeviceTokenByKey("alpha", "token-alpha");
+    await registry.countAll();
+    await registry.deleteDeviceByKey("alpha");
+    await registry.countAll();
+
+    expect(namespace.list).toHaveBeenCalledTimes(3);
+  });
+});

--- a/worker/test/mcp.test.ts
+++ b/worker/test/mcp.test.ts
@@ -248,6 +248,53 @@ describe("mcp compatibility", () => {
     expect(body.error!.message).toBe("Parse error");
   });
 
+  it("JSON-RPC batch arrays return invalid request instead of 202", async () => {
+    const { app } = createHarness();
+
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      ]),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await parseMcpResponse(res);
+    expect(body.error!.code).toBe(-32600);
+    expect(body.error!.message).toContain("batch");
+  });
+
+  it("non-object JSON-RPC bodies return invalid request", async () => {
+    const { app } = createHarness();
+
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(1),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await parseMcpResponse(res);
+    expect(body.error!.code).toBe(-32600);
+    expect(body.error!.message).toBe("Invalid Request");
+  });
+
+  it("objects missing JSON-RPC version return invalid request", async () => {
+    const { app } = createHarness();
+
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ method: "tools/list" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await parseMcpResponse(res);
+    expect(body.error!.code).toBe(-32600);
+    expect(body.error!.message).toBe("Invalid Request");
+  });
+
   it("accepts custom path device_key characters for Go compatibility", async () => {
     const harness = createHarness({
       registrySeed: { "bad$key": "bad-key-token" },
@@ -351,7 +398,7 @@ describe("mcp compatibility", () => {
     expect(body.result!.protocolVersion).toBe("2025-06-18");
   });
 
-  it("initialize with protocolVersion 2025-03-26 returns 2025-06-18", async () => {
+  it("initialize with protocolVersion 2025-03-26 returns 2025-03-26", async () => {
     const { app } = createHarness();
 
     const res = await jsonRpcRequest(app, "/mcp", "initialize", {
@@ -362,7 +409,34 @@ describe("mcp compatibility", () => {
 
     expect(res.status).toBe(200);
     const body = await parseMcpResponse(res);
-    expect(body.result!.protocolVersion).toBe("2025-06-18");
+    expect(body.result!.protocolVersion).toBe("2025-03-26");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-03-26");
+  });
+
+  it("initialize can negotiate from MCP-Protocol-Version header when params omit protocolVersion", async () => {
+    const { app } = createHarness();
+
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "mcp-protocol-version": "2025-03-26",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0" },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await parseMcpResponse(res);
+    expect(body.result!.protocolVersion).toBe("2025-03-26");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-03-26");
   });
 
   it("initialize with protocolVersion 2025-06-18 returns 2025-06-18", async () => {
@@ -379,7 +453,7 @@ describe("mcp compatibility", () => {
     expect(body.result!.protocolVersion).toBe("2025-06-18");
   });
 
-  it("initialize with unsupported protocolVersion returns 400", async () => {
+  it("initialize with legacy protocolVersion 2024-11-05 negotiates to 2025-06-18", async () => {
     const { app } = createHarness();
 
     const res = await jsonRpcRequest(app, "/mcp", "initialize", {
@@ -388,10 +462,25 @@ describe("mcp compatibility", () => {
       clientInfo: { name: "test", version: "1.0" },
     });
 
+    expect(res.status).toBe(200);
+    const body = await parseMcpResponse(res);
+    expect(body.result!.protocolVersion).toBe("2025-06-18");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-06-18");
+  });
+
+  it("initialize with invalid protocolVersion returns 400", async () => {
+    const { app } = createHarness();
+
+    const res = await jsonRpcRequest(app, "/mcp", "initialize", {
+      protocolVersion: "1.0.0",
+      capabilities: {},
+      clientInfo: { name: "test", version: "1.0" },
+    });
+
     expect(res.status).toBe(400);
     const body = await parseMcpResponse(res);
     expect(body.error!.code).toBe(-32602);
-    expect(body.error!.message).toContain("2024-11-05");
+    expect(body.error!.message).toContain("1.0.0");
   });
 
   // --- MCP-Protocol-Version header ---
@@ -499,7 +588,7 @@ describe("mcp compatibility", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-06-18");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-03-26");
   });
 
   // --- Origin header ---

--- a/worker/test/misc.test.ts
+++ b/worker/test/misc.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createHarness } from "./helpers/fakes";
 
@@ -52,6 +52,22 @@ describe("misc routes", () => {
       arch: "cloudflare/workerd",
       commit: "test-commit",
       devices: 2,
+    });
+  });
+
+  it("does not expose internal error messages from the global error handler", async () => {
+    const { app, registry } = createHarness();
+    registry.countAll = vi.fn(async () => {
+      throw new Error("internal kv cursor failed");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request("http://example.com/info");
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      code: 500,
+      message: "internal server error",
     });
   });
 });

--- a/worker/test/register.test.ts
+++ b/worker/test/register.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createHarness } from "./helpers/fakes";
 
@@ -209,6 +209,30 @@ describe("register routes", () => {
     await expect(response.json()).resolves.toMatchObject({
       code: 400,
       message: "key not found",
+    });
+  });
+
+  it("does not expose internal storage errors during registration", async () => {
+    const { app, registry } = createHarness();
+    registry.saveDeviceTokenByKey = vi.fn(async () => {
+      throw new Error("kv write failed");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request("http://example.com/register", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        device_token: "device-token",
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      code: 500,
+      message: "internal server error",
     });
   });
 });


### PR DESCRIPTION
各修复点评估

  1. 版本协商(核心问题)—— 修得非常到位

  mcp.ts:237 新增 negotiateInitializeProtocolVersion,精确区分了我引用的规范两条路径:
  - 已知的旧版本 2024-11-05 → 200 + 降级到 2025-06-18(符合 Version Negotiation 的 MUST respond with another version it supports)。
  - 无法识别的版本 1.0.0 → 400 / -32602(符合 Error Handling 一节)。

  值得点出:新增的 400 测试用例恰好用 "1.0.0" —— 这正是 MCP 规范错误示例里的那个 requested 值。修复严丝合缝地踩在了规范的语义边界上。额外还支持了"params 省略
  protocolVersion 时从 MCP-Protocol-Version 头协商"这一健壮回退,超出预期。

  2. session 边界 —— 文档已澄清

  README 把 MCP_SESSION_SECRET 加入"加固变量"清单,并明确:"It is not an access-control boundary: requests without Mcp-Session-Id are still accepted… use Basic
  Auth to restrict MCP access." 行为(有意保持可选)未变,但语义不再有误导风险。这正是我那条 finding 的诉求。

  3. 常量时间比较 —— 按建议落地

  timingSafeStringEqual 抽到 worker/src/timing-safe.ts,auth.ts 与 mcp.ts 共用,session 签名校验改为 !timingSafeStringEqual(signatureB64,
  expectedSig)(mcp.ts:170)。util 还顺手处理了 undefined,无重复实现。

  4. 批量/非法 body —— 显式拒绝且更健壮

  mcp.ts:545 起:数组 → 400 "batch requests are not supported";新增 isJsonRpcObject/isRecord 守卫,缺 jsonrpc:"2.0" 或非对象 → 400 "Invalid Request"。比单纯修 bug
  更进一步,补齐了 JSON-RPC 信封校验。三个新测试覆盖到位,文档也注明。

  5. 协商版本回显 —— 全链路打通

  responseProtocolVersion 在 header 校验、Origin/Accept、session、dispatch、202、405 各分支统一透传;initialize result 也改回
  negotiation.version。测试相应更新("2025-03-26 returns 2025-03-26" + 头断言),原先硬编码 2025-06-18 的 202 分支也改用 setProtocolHeader。

  ---
  新代码是否引入问题?—— 未发现

  我重点核对了几条易错路径:
  - 双重协商:handlePost 协商成功时把 negotiatedInitializeProtocolVersion 透传给 handleMcpRequest 避免重算;失败时(如 1.0.0)透传 undefined,由 handler 重算并返回
  400。逻辑自洽。
  - mismatch 检查与协商顺序:clientVersion="1.0.0" + header="2025-03-26" 会先被 mismatch 检查拦下(400),不会误入协商;非法 header 在最顶端就已 400。边界都封住了。
  - isJsonRpcObject 收紧:要求 jsonrpc==="2.0"。理论上更严,但所有现存测试与 MCP/JSON-RPC 规范本就要求该字段,兼容风险极低。

  残留小项(可忽略,非阻塞)

  - SessionPayload.protocolVersion 仍是"写入但在 validateSessionToken 中不校验"的装饰字段 —— 纯 cosmetic。
  - "session 未启用 → 400" 仍早于 body 解析(id:null)—— 极边缘,未改。
  - 一个版本声明 2025-03-26 的客户端会被回显 2025-03-26 却被拒绝批量(该版本理论允许批量)。属可接受取舍,且文档已写明。

  ---
  修复验证报告

  总览

  ┌──────────────────────────────────────┬──────┬────────────────────────────┐
  │                Commit                │ 对应 │            结论            │
  ├──────────────────────────────────────┼──────┼────────────────────────────┤
  │ 12fbb58 auth-free route matching     │ H1   │ ⚠️ 基本修复,但有残留(见下) │
  ├──────────────────────────────────────┼──────┼────────────────────────────┤
  │ fba97f9 finite default batch limit   │ H2   │ ✅ 正确                    │
  ├──────────────────────────────────────┼──────┼────────────────────────────┤
  │ b0c0869 protect reserved APNs fields │ M2   │ ✅ 已验证                  │
  ├──────────────────────────────────────┼──────┼────────────────────────────┤
  │ 6d8ec5a hide internals from 5xx      │ M3   │ ✅ 基本到位(1 处小残留)    │
  ├──────────────────────────────────────┼──────┼────────────────────────────┤
  │ 3031125 cache device counts          │ M4   │ ✅ 正确                    │
  ├──────────────────────────────────────┼──────┼────────────────────────────┤
  │ c252ff1 encode device tokens         │ L1   │ ✅ 已验证                  │
  ├──────────────────────────────────────┼──────┼────────────────────────────┤
  │ 25b84c3 rejection sampling           │ L5   │ ✅ 正确                    │
  └──────────────────────────────────────┴──────┴────────────────────────────┘

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and MCP docs: validation status, MCP_SESSION_SECRET behavior, one-message-per-POST requirement, and Basic Auth guidance (including Chinese text updates)

* **Bug Fixes**
  * Hardened MCP protocol negotiation and made session signature checks timing-safe
  * Consistent protocol version headers on errors and responses

* **Behavioral**
  * Error responses now hide internal details for 5xx and registration failures

* **Performance / Caching**
  * Cached device-count results with proper invalidation

* **APNs**
  * Prevent custom payload keys from overwriting built-in fields and ensure device tokens are URL-encoded

* **Utilities**
  * Improved unbiased device key generation

* **Tests**
  * Expanded test coverage for MCP, auth, device keys, APNs, config, caching, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->