### PR TITLE
feat: add `closeRegister` option to disable new device registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ The Worker implementation is usable in production for the main Bark flows.
 
 Current validation coverage:
 
-- `92` automated tests passing with `pnpm test`
+- `111` automated tests passing with `pnpm test`
 - TypeScript checks passing with `pnpm check`
 - Wrangler dry-run build passing with `pnpm build`
 - Live smoke tests confirmed for legacy push, `/push`, `/mcp`, and `/mcp/:device_key`
 
-> **中文说明：** Worker 实现已可用于生产环境，覆盖主要 Bark 推送流程。旧版推送路由、`POST /push`、MCP 端点均已可用，APNs 推送经过真机验证，兼容性行为由自动化合约测试覆盖。当前 92 个自动化测试全部通过。
+> **中文说明：** Worker 实现已可用于生产环境，覆盖主要 Bark 推送流程。旧版推送路由、`POST /push`、MCP 端点均已可用，APNs 推送经过真机验证，兼容性行为由自动化合约测试覆盖。当前 111 个自动化测试全部通过。
 
 ## Migration Approach
 
@@ -215,8 +215,9 @@ Optional hardening variables ｜ 可选安全加固变量:
 - `MAX_BATCH_PUSH_COUNT` limits V2 batch fan-out when `device_keys` is provided. The default is `1000`; set `-1` only if you intentionally want no application-level cap.
 - `MAX_REQUEST_BODY_BYTES` limits parsed request bodies for JSON/form/MCP requests. The default is `4194304` bytes.
 - `MCP_SESSION_SECRET` signs optional MCP session IDs. It is not an access-control boundary: requests without `Mcp-Session-Id` are still accepted for compatibility, so use Basic Auth to restrict MCP access.
+- `CLOSE_REGISTER` disables new device registration when set to `"true"`. `POST /register` and `GET /register` return `403`, while `GET /register/:device_key` (key lookup) still works. Default is open.
 
-> **中文说明：** `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` 保护所有非兼容性免费路由（`/`、`/ping`、`/healthz`、`/register` 仍绕过认证以保持 Bark 兼容）。`MAX_BATCH_PUSH_COUNT` 限制 `device_keys` 批量推送数量，默认 `1000`；只有在你明确接受无应用层上限时才应设为 `-1`。`MAX_REQUEST_BODY_BYTES` 限制 JSON/form/MCP 请求体大小，默认 4MB。`MCP_SESSION_SECRET` 用于签名可选 MCP session ID，但它不是访问控制边界；为了兼容，未携带 `Mcp-Session-Id` 的请求仍会被接受，限制 MCP 访问请使用 Basic Auth。
+> **中文说明：** `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` 保护所有非兼容性免费路由（`/`、`/ping`、`/healthz`、`/register` 仍绕过认证以保持 Bark 兼容）。`MAX_BATCH_PUSH_COUNT` 限制 `device_keys` 批量推送数量，默认 `1000`；只有在你明确接受无应用层上限时才应设为 `-1`。`MAX_REQUEST_BODY_BYTES` 限制 JSON/form/MCP 请求体大小，默认 4MB。`MCP_SESSION_SECRET` 用于签名可选 MCP session ID，但它不是访问控制边界；为了兼容，未携带 `Mcp-Session-Id` 的请求仍会被接受，限制 MCP 访问请使用 Basic Auth。`CLOSE_REGISTER` 设为 `"true"` 时关闭新设备注册，`POST /register` 和 `GET /register` 返回 `403`，`GET /register/:device_key`（密钥查询）不受影响；默认开放。
 
 If you prefer, `APNS_PRIVATE_KEY` can be stored as a Cloudflare secret instead of plaintext config:
 

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -22,7 +22,9 @@ export function parseMaxBatchPushCount(raw?: string): number {
     return -1;
   }
 
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_BATCH_PUSH_COUNT;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_BATCH_PUSH_COUNT;
 }
 
 export function parseMaxRequestBodyBytes(raw?: string): number {
@@ -31,7 +33,17 @@ export function parseMaxRequestBodyBytes(raw?: string): number {
   }
 
   const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_REQUEST_BODY_BYTES;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_REQUEST_BODY_BYTES;
+}
+
+export function parseCloseRegister(raw?: string | boolean): boolean {
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+
+  return raw?.trim().toLowerCase() === "true";
 }
 
 export function createConfigFromEnv(env: BarkBindings): AppConfig {
@@ -42,6 +54,7 @@ export function createConfigFromEnv(env: BarkBindings): AppConfig {
     maxBatchPushCount: parseMaxBatchPushCount(env.MAX_BATCH_PUSH_COUNT),
     maxRequestBodyBytes: parseMaxRequestBodyBytes(env.MAX_REQUEST_BODY_BYTES),
     mcpSessionSecret: env.MCP_SESSION_SECRET,
+    closeRegister: parseCloseRegister(env.CLOSE_REGISTER),
   };
 }
 

--- a/worker/src/register.ts
+++ b/worker/src/register.ts
@@ -52,6 +52,10 @@ async function parseRegisterBody(request: Request, maxBodyBytes: number): Promis
 }
 
 async function doRegister(c: Context, options: RegisterRouteOptions, compat: boolean) {
+  if (options.config.closeRegister) {
+    return c.json(failed(options.deps.now(), 403, "registration is closed"), 403);
+  }
+
   let deviceInfo: DeviceInfo = {};
 
   try {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -19,6 +19,7 @@ export interface AppConfig {
   maxBatchPushCount: number;
   maxRequestBodyBytes: number;
   mcpSessionSecret?: string;
+  closeRegister: boolean;
 }
 
 export interface BarkBindings {
@@ -29,6 +30,7 @@ export interface BarkBindings {
   MAX_BATCH_PUSH_COUNT?: string;
   MAX_REQUEST_BODY_BYTES?: string;
   MCP_SESSION_SECRET?: string;
+  CLOSE_REGISTER?: string | boolean;
   APP_VERSION?: string;
   APP_BUILD?: string;
   APP_COMMIT?: string;

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_MAX_BATCH_PUSH_COUNT, parseMaxBatchPushCount } from "@/config";
+import { DEFAULT_MAX_BATCH_PUSH_COUNT, parseCloseRegister, parseMaxBatchPushCount } from "@/config";
 
 describe("parseMaxBatchPushCount", () => {
   it("uses a finite default when the env var is absent", () => {
@@ -14,5 +14,24 @@ describe("parseMaxBatchPushCount", () => {
   it("falls back to the finite default for invalid values", () => {
     expect(parseMaxBatchPushCount("0")).toBe(DEFAULT_MAX_BATCH_PUSH_COUNT);
     expect(parseMaxBatchPushCount("abc")).toBe(DEFAULT_MAX_BATCH_PUSH_COUNT);
+  });
+});
+
+describe("parseCloseRegister", () => {
+  it("returns false when the env var is absent", () => {
+    expect(parseCloseRegister()).toBe(false);
+  });
+
+  it("accepts boolean true and case-insensitive string true", () => {
+    expect(parseCloseRegister(true)).toBe(true);
+    expect(parseCloseRegister("true")).toBe(true);
+    expect(parseCloseRegister("TRUE")).toBe(true);
+    expect(parseCloseRegister(" True ")).toBe(true);
+  });
+
+  it("returns false for boolean false and non-true strings", () => {
+    expect(parseCloseRegister(false)).toBe(false);
+    expect(parseCloseRegister("false")).toBe(false);
+    expect(parseCloseRegister("1")).toBe(false);
   });
 });

--- a/worker/test/helpers/fakes.ts
+++ b/worker/test/helpers/fakes.ts
@@ -109,6 +109,7 @@ export function createHarness(options: TestHarnessOptions = {}): TestHarness {
     maxBatchPushCount: DEFAULT_MAX_BATCH_PUSH_COUNT,
     maxRequestBodyBytes: 4 * 1024 * 1024,
     mcpSessionSecret: undefined,
+    closeRegister: false,
     ...options.config,
   };
 

--- a/worker/test/register.test.ts
+++ b/worker/test/register.test.ts
@@ -212,6 +212,52 @@ describe("register routes", () => {
     });
   });
 
+  it("returns 403 when registration is closed (POST)", async () => {
+    const { app } = createHarness({ config: { closeRegister: true } });
+
+    const response = await app.request("http://example.com/register", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        device_token: "device-token",
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      code: 403,
+      message: "registration is closed",
+      timestamp: 1_717_900_000,
+    });
+  });
+
+  it("returns 403 when registration is closed (GET compat)", async () => {
+    const { app } = createHarness({ config: { closeRegister: true } });
+
+    const response = await app.request(
+      "http://example.com/register?devicetoken=device-token-1",
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      code: 403,
+      message: "registration is closed",
+    });
+  });
+
+  it("still allows device key checks when registration is closed", async () => {
+    const { app } = createHarness({
+      config: { closeRegister: true },
+      registrySeed: { alpha: "token-alpha" },
+    });
+
+    const response = await app.request("http://example.com/register/alpha");
+
+    expect(response.status).toBe(200);
+  });
+
   it("does not expose internal storage errors during registration", async () => {
     const { app, registry } = createHarness();
     registry.saveDeviceTokenByKey = vi.fn(async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,9 @@ compatibility_date = "2026-06-12"
 enabled = true
 
 [vars]
+# 稳定后可以考虑关闭新设备的注册，防止他人滥用
+CLOSE_REGISTER = false
+# 保持默认即可，除非你知道你在干什么
 APNS_TOPIC = "me.fin.bark"
 APNS_KEY_ID = "LH4T9V5U4R"
 APNS_TEAM_ID = "5U8LBRXG3A"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to close user registrations via a new `CLOSE_REGISTER` configuration option. When enabled, registration endpoints return 403 errors while device key lookups remain functional.

* **Documentation**
  * Updated configuration documentation with details on the new registration closure feature.

* **Quality**
  * Test suite expanded to 111 passing tests (previously 92), including comprehensive coverage for the new registration closure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->