### PR TITLE
Bump MCP protocol version to 2025-11-25 for Claude Code

### DIFF
--- a/worker/src/mcp.ts
+++ b/worker/src/mcp.ts
@@ -11,13 +11,17 @@ export interface McpRouteOptions {
   deps: RuntimeDeps;
 }
 
-const ACCEPTED_PROTOCOL_VERSIONS = ["2025-03-26", "2025-06-18"] as const;
+const ACCEPTED_PROTOCOL_VERSIONS = [
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+] as const;
 const LEGACY_INITIALIZE_PROTOCOL_VERSIONS = ["2024-11-05"] as const;
 const SUPPORTED_PROTOCOL_VERSIONS = new Set<string>(ACCEPTED_PROTOCOL_VERSIONS);
 const LEGACY_INITIALIZE_PROTOCOL_VERSION_SET = new Set<string>(
   LEGACY_INITIALIZE_PROTOCOL_VERSIONS,
 );
-const SERVER_PROTOCOL_VERSION = "2025-06-18";
+const SERVER_PROTOCOL_VERSION = "2025-11-25";
 const SESSION_TTL_SECONDS = 24 * 60 * 60;
 const PROTOCOL_HEADER = "MCP-Protocol-Version";
 
@@ -234,6 +238,10 @@ function validateProtocolHeader(headerValue: string | undefined): ProtocolValida
   return { valid: false, version: headerValue };
 }
 
+function isProtocolVersionDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
 function negotiateInitializeProtocolVersion(
   clientVersion: string | undefined,
 ): InitializeNegotiationResult {
@@ -246,6 +254,10 @@ function negotiateInitializeProtocolVersion(
   }
 
   if (LEGACY_INITIALIZE_PROTOCOL_VERSION_SET.has(clientVersion)) {
+    return { valid: true, version: SERVER_PROTOCOL_VERSION };
+  }
+
+  if (isProtocolVersionDate(clientVersion)) {
     return { valid: true, version: SERVER_PROTOCOL_VERSION };
   }
 

--- a/worker/test/mcp.test.ts
+++ b/worker/test/mcp.test.ts
@@ -385,7 +385,7 @@ describe("mcp compatibility", () => {
 
   // --- Version negotiation ---
 
-  it("initialize with absent protocolVersion returns 2025-06-18", async () => {
+  it("initialize with absent protocolVersion returns 2025-11-25", async () => {
     const { app } = createHarness();
 
     const res = await jsonRpcRequest(app, "/mcp", "initialize", {
@@ -395,7 +395,7 @@ describe("mcp compatibility", () => {
 
     expect(res.status).toBe(200);
     const body = await parseMcpResponse(res);
-    expect(body.result!.protocolVersion).toBe("2025-06-18");
+    expect(body.result!.protocolVersion).toBe("2025-11-25");
   });
 
   it("initialize with protocolVersion 2025-03-26 returns 2025-03-26", async () => {
@@ -453,7 +453,22 @@ describe("mcp compatibility", () => {
     expect(body.result!.protocolVersion).toBe("2025-06-18");
   });
 
-  it("initialize with legacy protocolVersion 2024-11-05 negotiates to 2025-06-18", async () => {
+  it("initialize with protocolVersion 2025-11-25 returns 2025-11-25", async () => {
+    const { app } = createHarness();
+
+    const res = await jsonRpcRequest(app, "/mcp", "initialize", {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "claude-code", version: "1.0" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await parseMcpResponse(res);
+    expect(body.result!.protocolVersion).toBe("2025-11-25");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-11-25");
+  });
+
+  it("initialize with legacy protocolVersion 2024-11-05 negotiates to 2025-11-25", async () => {
     const { app } = createHarness();
 
     const res = await jsonRpcRequest(app, "/mcp", "initialize", {
@@ -464,8 +479,23 @@ describe("mcp compatibility", () => {
 
     expect(res.status).toBe(200);
     const body = await parseMcpResponse(res);
-    expect(body.result!.protocolVersion).toBe("2025-06-18");
-    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-06-18");
+    expect(body.result!.protocolVersion).toBe("2025-11-25");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-11-25");
+  });
+
+  it("initialize with unknown date protocolVersion negotiates to server latest", async () => {
+    const { app } = createHarness();
+
+    const res = await jsonRpcRequest(app, "/mcp", "initialize", {
+      protocolVersion: "2026-01-01",
+      capabilities: {},
+      clientInfo: { name: "future-client", version: "1.0" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await parseMcpResponse(res);
+    expect(body.result!.protocolVersion).toBe("2025-11-25");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-11-25");
   });
 
   it("initialize with invalid protocolVersion returns 400", async () => {
@@ -490,7 +520,7 @@ describe("mcp compatibility", () => {
 
     const res = await jsonRpcRequest(app, "/mcp", "tools/list");
 
-    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-06-18");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-11-25");
   });
 
   it("405 responses include MCP-Protocol-Version header", async () => {
@@ -499,7 +529,7 @@ describe("mcp compatibility", () => {
     const res = await app.request("/mcp", { method: "GET" });
 
     expect(res.status).toBe(405);
-    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-06-18");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-11-25");
   });
 
   // --- Notification response status ---
@@ -572,7 +602,7 @@ describe("mcp compatibility", () => {
     expect(res.status).toBe(400);
     const body = await parseMcpResponse(res);
     expect(body.error!.message).toContain("Unsupported protocol version");
-    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-06-18");
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-11-25");
   });
 
   it("supported MCP-Protocol-Version header proceeds normally", async () => {
@@ -589,6 +619,22 @@ describe("mcp compatibility", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-03-26");
+  });
+
+  it("latest MCP-Protocol-Version header proceeds normally", async () => {
+    const { app } = createHarness();
+
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "mcp-protocol-version": "2025-11-25",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("MCP-Protocol-Version")).toBe("2025-11-25");
   });
 
   // --- Origin header ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated MCP protocol version to `2025-11-25`
  * Enhanced protocol version negotiation to support date-formatted versions for improved compatibility across client protocol versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->